### PR TITLE
FOGL-3160: Changed script type item order to show as first item in config[1.7.0RC]

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -59,12 +59,12 @@
 			"\"config\" : {\"description\" : \"Python 2.7 filter configuration.\", " \
 				"\"type\" : \"JSON\", " \
 				"\"displayName\" : \"Configuration\", " \
-				"\"order\": \"1\", " \
+				"\"order\": \"2\", " \
 				"\"default\" : \"{}\"}, " \
 			"\"script\" : {\"description\" : \"Python 2.7 module to load.\", " \
 				"\"type\": \"script\", " \
 				"\"displayName\" : \"Python Script\", " \
-				"\"order\": \"2\", " \
+				"\"order\": \"1\", " \
 				"\"default\": \"""\"} }"
 
 bool pythonInitialised = false;


### PR DESCRIPTION
Before changing script item order 
![Screen Shot 2019-08-20 at 1 31 49 PM](https://user-images.githubusercontent.com/16384273/63329565-da12ab00-c34f-11e9-8c2b-be3c454a3c57.png)

After changing script item order 
![Screen Shot 2019-08-20 at 1 31 02 PM](https://user-images.githubusercontent.com/16384273/63329613-e5fe6d00-c34f-11e9-8436-87bef342d4f9.png)
